### PR TITLE
Set default modal style to full-screen

### DIFF
--- a/TiltUp/Classes/Architecture/Coordinator.swift
+++ b/TiltUp/Classes/Architecture/Coordinator.swift
@@ -66,9 +66,9 @@ public extension Router {
 
 public extension Router {
     // MARK: Presenting modals
-    func presentModal(_ viewController: UIViewController, retaining coordinator: Coordinating, animated: Bool = true, dismissHandler: (() -> Void)? = nil) {
+    func presentModal(_ viewController: UIViewController, retaining coordinator: Coordinating, animated: Bool = true, presentationStyle: UIModalPresentationStyle = .fullScreen, dismissHandler: (() -> Void)? = nil) {
         coordinator.appCoordinator.pushCoordinator(coordinator)
-        presentModal(viewController, animated: animated) { [weak coordinator] in
+        presentModal(viewController, animated: animated, presentationStyle: presentationStyle) { [weak coordinator] in
             dismissHandler?()
             if let coordinator = coordinator {
                 coordinator.appCoordinator.popCoordinator(coordinator)
@@ -76,9 +76,9 @@ public extension Router {
         }
     }
 
-    func presentModal(_ router: Router, retaining coordinator: Coordinating, animated: Bool = true, dismissHandler: (() -> Void)? = nil) {
+    func presentModal(_ router: Router, retaining coordinator: Coordinating, animated: Bool = true, presentationStyle: UIModalPresentationStyle = .fullScreen, dismissHandler: (() -> Void)? = nil) {
         coordinator.appCoordinator.pushCoordinator(coordinator)
-        presentModal(router, animated: animated) { [weak coordinator] in
+        presentModal(router, animated: animated, presentationStyle: presentationStyle) { [weak coordinator] in
             dismissHandler?()
             if let coordinator = coordinator {
                 coordinator.appCoordinator.popCoordinator(coordinator)

--- a/TiltUp/Classes/Architecture/Router.swift
+++ b/TiltUp/Classes/Architecture/Router.swift
@@ -89,15 +89,16 @@ public extension Router {
 
 public extension Router {
     // MARK: Presenting modals
-    func presentModal(_ viewController: UIViewController, animated: Bool = true, dismissHandler: (() -> Void)? = nil) {
+    func presentModal(_ viewController: UIViewController, animated: Bool = true, presentationStyle: UIModalPresentationStyle = .fullScreen, dismissHandler: (() -> Void)? = nil) {
+        viewController.modalPresentationStyle = presentationStyle
         navigationController.present(viewController, animated: animated) {
             self.dismissHandler = dismissHandler
         }
     }
 
-    func presentModal(_ router: Router, animated: Bool = true, dismissHandler: (() -> Void)? = nil) {
+    func presentModal(_ router: Router, animated: Bool = true, presentationStyle: UIModalPresentationStyle = .fullScreen, dismissHandler: (() -> Void)? = nil) {
         self.presentedRouter = router
-        presentModal(router.navigationController, animated: animated, dismissHandler: dismissHandler)
+        presentModal(router.navigationController, animated: animated, presentationStyle: presentationStyle, dismissHandler: dismissHandler)
     }
 
     // MARK: Dismissing modals


### PR DESCRIPTION
iOS 13 presents modals as page views by default. This causes visual changes, but more importantly allows swiping to dismiss modals. To avoid these changes, `Router` now explicitly defaults to full-screen modal presentation.

## Pivotal Tracker tickets
[Update Dock and Forklift for Xcode 11](https://www.pivotaltracker.com/story/show/168764822)

## Screenshots
iOS 13 (before change) | iOS 13 (after change) and iOS 12
--- | ---
![Before](https://user-images.githubusercontent.com/2874864/65804528-14cde700-e137-11e9-9dba-ec68ff1e3702.png) | ![After](https://user-images.githubusercontent.com/2874864/65804636-73936080-e137-11e9-8f32-accced5b2156.png)
