### PR TITLE
Add a convenience init for nillable Observables

### DIFF
--- a/TiltUp/Classes/Utilities/Observables.swift
+++ b/TiltUp/Classes/Utilities/Observables.swift
@@ -63,6 +63,12 @@ public final class Observable<Observed> {
     }
 }
 
+extension Observable where Observed: ExpressibleByNilLiteral {
+    public convenience init() {
+        self.init(wrappedValue: nil)
+    }
+}
+
 public final class ObserverList<Observed> {
     public typealias Observer = (Observed) -> Void
     fileprivate var observers: [UUID: (DispatchQueue, Observer)] = [:]


### PR DESCRIPTION
`Observable<Observed>(wrappedValue: nil)` → `Observable<Observed>()`