### PR TITLE
Shutter Blacks Screen for Entirety of Capture

### DIFF
--- a/TiltUp/Classes/Screens/Camera/CameraController.swift
+++ b/TiltUp/Classes/Screens/Camera/CameraController.swift
@@ -71,6 +71,12 @@ public final class CameraController: UIViewController {
             DispatchQueue.main.async {
                 self.generator.impactOccurred()
                 self.previewView.videoPreviewLayer.opacity = 0
+            }
+        }
+
+        viewModel.viewObservers.didCapturePhotoAnimation = { [weak self] in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
                 UIView.animate(withDuration: 0.25) {
                     self.previewView.videoPreviewLayer.opacity = 1
                 }

--- a/TiltUp/Classes/Screens/Camera/CameraViewModel.swift
+++ b/TiltUp/Classes/Screens/Camera/CameraViewModel.swift
@@ -32,6 +32,7 @@ public enum Camera {
         var updateOverlayState: ((CameraOverlayView.State) -> Void)?
         var updatePreviewSession: ((AVCaptureSession) -> Void)?
         var willCapturePhotoAnimation: (() -> Void)?
+        var didCapturePhotoAnimation: (() -> Void)?
     }
 }
 
@@ -303,6 +304,8 @@ private extension CameraViewModel {
         sessionQueue.async {
             self.inProgressPhotoCaptureDelegates[photoCaptureDelegate.uniqueID] = nil
         }
+
+        viewObservers.didCapturePhotoAnimation?()
     }
 }
 

--- a/TiltUp/Classes/Screens/Camera/PhotoCaptureDelegate.swift
+++ b/TiltUp/Classes/Screens/Camera/PhotoCaptureDelegate.swift
@@ -37,9 +37,7 @@ final class PhotoCaptureDelegate: NSObject {
 }
 
 extension PhotoCaptureDelegate: AVCapturePhotoCaptureDelegate {
-    func photoOutput(_ output: AVCapturePhotoOutput, willBeginCaptureFor resolvedSettings: AVCaptureResolvedPhotoSettings) {}
-
-    func photoOutput(_ output: AVCapturePhotoOutput, willCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+    func photoOutput(_ output: AVCapturePhotoOutput, willBeginCaptureFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
         willCapturePhotoAnimation?()
     }
 


### PR DESCRIPTION
Instead of a fixed timer, the shutter blackens screen for entirety of
capture event.
