### PR TITLE
Yields PhotoCapture Object

### DIFF
--- a/Example/TiltUp/Screens/Camera/CameraCoordinator.swift
+++ b/Example/TiltUp/Screens/Camera/CameraCoordinator.swift
@@ -29,8 +29,17 @@ private extension CameraCoordinator {
             guard let self = self else { return }
             self.router.dismissModal()
         }
-        viewModel.coordinatorObservers.capturedPhotos = { photos in
-            print("Photo Captured \(photos.count)")
+        viewModel.coordinatorObservers.capturedPhotos = { photoCaptures in
+            print("Captured \(photoCaptures.count) Photos")
+            for (i, photoCapture) in photoCaptures.enumerated() {
+                print(
+                    """
+                    Photo \(i):
+                        Expected Duration: \(photoCapture.expectedCaptureDuration.converted(to: .seconds))
+                        Actual Duration: \(photoCapture.actualCaptureDuration.converted(to: .seconds))
+                    """
+                )
+            }
         }
 
         let cameraController = CameraController(viewModel: viewModel, hint: { numberOfPhotos in

--- a/TiltUp/Classes/Screens/Camera/PhotoCapture.swift
+++ b/TiltUp/Classes/Screens/Camera/PhotoCapture.swift
@@ -1,0 +1,28 @@
+//
+//  PhotoCapture.swift
+//  TiltUp
+//
+//  Created by Robert Manson on 3/4/20.
+//
+
+import Foundation
+import AVFoundation
+
+public struct PhotoCapture {
+    public let fileDataRepresentation: Data
+    public let expectedCaptureDuration: Measurement<UnitDuration>
+    public let actualCaptureDuration: Measurement<UnitDuration>
+
+    init?(
+        capture: AVCapturePhoto,
+        expectedCaptureDuration: Measurement<UnitDuration>,
+        actualCaptureDuration: Measurement<UnitDuration>
+    ) {
+        guard let fileDataRepresentation = capture.fileDataRepresentation() else {
+            return nil
+        }
+        self.fileDataRepresentation = fileDataRepresentation
+        self.expectedCaptureDuration = expectedCaptureDuration
+        self.actualCaptureDuration = actualCaptureDuration
+    }
+}

--- a/TiltUp/Classes/Screens/Camera/Views/CameraOverlayView.swift
+++ b/TiltUp/Classes/Screens/Camera/Views/CameraOverlayView.swift
@@ -14,7 +14,7 @@ protocol CameraOverlayViewDelegate: AnyObject {
     func confirmPictures()
     func takePicture()
     func retakePicture()
-    func usePicture(_ image: UIImage, canContinue: Bool)
+    func usePicture(_ photoCapture: PhotoCapture, canContinue: Bool)
     func cancelCamera()
 }
 
@@ -42,7 +42,7 @@ final class CameraOverlayView: UIView {
     enum State {
         case start(count: Int, canComplete: Bool)
         case capture
-        case confirm(image: UIImage, canContinue: Bool)
+        case confirm(photoCapture: PhotoCapture, canContinue: Bool)
     }
 
     private var hint: (_ numberOfPhotos: Int) -> String?
@@ -72,16 +72,12 @@ final class CameraOverlayView: UIView {
                 saveButton.isHidden = true
                 shutterButton.isHidden = true
 
-            case let .confirm(image, canContinue):
+            case let .confirm(photoCapture, canContinue):
                 cancelButton.isHidden = true
                 countLabel.isHidden = true
                 doneButton.isHidden = true
                 flashButton.isHidden = true
-                if let cgImage = image.cgImage {
-                    previewImageView.image = UIImage(cgImage: cgImage, scale: image.scale, orientation: .right)
-                } else {
-                    previewImageView.image = image
-                }
+                previewImageView.image = UIImage(data: photoCapture.fileDataRepresentation)
                 retakeButton.isHidden = false
                 saveButton.setTitle(canContinue ? "Continue" : "Use Photo", for: .normal)
                 saveButton.isHidden = false


### PR DESCRIPTION
Instead of plain data, snapping photos yields an object that also
includes information about how long the expected and actual shutter
duration was.

Pivotal ticket for Field app:
https://www.pivotaltracker.com/story/show/171430275