### PR TITLE
Prevent cascading failures in testUI

### DIFF
--- a/TiltUpTest/Assertions/XCTestCase+testUI.swift
+++ b/TiltUpTest/Assertions/XCTestCase+testUI.swift
@@ -10,13 +10,22 @@ import XCTest
 
 public extension XCTestCase {
     func testUI(setup: @escaping () -> Void, assertions: @escaping () -> Void) {
+        var cancellableSetup: (() -> Void)? = setup
+        var cancellableAssertions: (() -> Void)? = assertions
         let mainThreadExpectation = expectation(description: "Wait for main thread code to run")
-
-        UIView.animate(withDuration: 0.0, animations: setup, completion: { _ in
-            assertions()
-            mainThreadExpectation.fulfill()
-        })
+        UIView.animate(
+            withDuration: 0.0,
+            animations: {
+                cancellableSetup?()
+            },
+            completion: { _ in
+                cancellableAssertions?()
+                mainThreadExpectation.fulfill()
+            }
+        )
 
         wait(for: [mainThreadExpectation])
+        cancellableSetup = nil
+        cancellableAssertions = nil
     }
 }


### PR DESCRIPTION
- If the testUI(_:,_:) assertion fails, don't call the assertion closure
- This prevents retained closures from being called during subsequent
  tests, which leads to cascading failures and crashes

## Pivotal Tracker tickets
N/A

## Screenshots
n/A
