### PR TITLE
Remove Private Specs Repo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,27 @@
 # TiltUp
 
+## Installing
+
+TiltUp can be installed either using Cocoapods or Swift Package Mangager
+
+### Cocoapods
+To add TiltUp into your Xcode project using CocoaPods, specify it in the `Podfile`:
+```
+// Podfile
+pod 'TiltUp'
+```
+
+### Swift Package Manager
+Once you have your Swift package set up, just add TiltUp as one of your dependencies in the `Package.swift` file:
+```
+dependencies: [
+    .package(url: "https://github.com/clutter/TiltUp.git", .upToNextMajor(from: "2.8.1"))
+]
+```
+
 ## Example
 
 To run the example project, clone the repo, and run `pod install` from the Example directory first.
-
-## Installing
-
-TiltUp is available via Clutter's private CocoaPods repo. To include it in your project you will need to add a few lines to your `Podfile`:
-
-1. Include the `clutter/Specs` repo as one of your pod sources:
-
-    ```ruby
-    source 'git@github.com:clutter/Specs.git'
-    ```
-
-2. Add the TiltUp pod:
-
-    ```ruby
-    pod 'TiltUp'
-    ```
-
-    1. Optionally add the TiltUpTest pod to your test target:
-
-        ```ruby
-        pod 'TiltUpTest'
-        ```
-
-3. Add & update the private pod repo, then install the pod:
-
-```
-bundle exec pod repo add clutter-specs git@github.com:clutter/Specs.git
-bundle exec pod repo update clutter-specs
-bundle exec pod install
-```
 
 ## TiltUp Usage
 


### PR DESCRIPTION
Updates README to no longer reference the private specs repo

## Pivotal Tracker tickets
N/A

## Screenshots
N/A
