### PR TITLE
Support Camera View in Simulator

### DIFF
--- a/Example/PodApp/Podfile.lock
+++ b/Example/PodApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - SwiftLint (0.34.0)
-  - TiltUp (2.8.1)
-  - TiltUpTest (2.8.1):
-    - TiltUp (= 2.8.1)
+  - TiltUp (3.1.0)
+  - TiltUpTest (3.1.0):
+    - TiltUp (= 3.1.0)
 
 DEPENDENCIES:
   - SwiftLint
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   SwiftLint: 79d48a17c6565dc286c37efb8322c7b450f95c67
-  TiltUp: 1faef29c73efea74f261ceedc24bcc620d48f96f
-  TiltUpTest: 54580c30690a13200352ca0eca275bc5ed2f7408
+  TiltUp: 43e69ef22cdba68167a0b4380fc91ed6a741c90a
+  TiltUpTest: be361829df0ae5a2b6a8548f90587bc08fbc119e
 
 PODFILE CHECKSUM: 0e23ef3e43ff7a2a471fd59d57def6d19f6f9e9e
 

--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,1 @@
-realm/SwiftLint@0.43.1
-
+realm/SwiftLint@0.44.0

--- a/Sources/TiltUp/Screens/Camera/CameraController.swift
+++ b/Sources/TiltUp/Screens/Camera/CameraController.swift
@@ -117,7 +117,6 @@ public final class CameraController: UIViewController {
 
         overlayView.frame = view.bounds
         previewView.frame = overlayView.previewImageView.frame
-        
     }
 }
 

--- a/Sources/TiltUp/Screens/Camera/PhotoCapture.swift
+++ b/Sources/TiltUp/Screens/Camera/PhotoCapture.swift
@@ -13,6 +13,16 @@ public struct PhotoCapture {
     public let expectedCaptureDuration: Measurement<UnitDuration>
     public let actualCaptureDuration: Measurement<UnitDuration>
 
+    static func mock() -> PhotoCapture? {
+        let image = UIImage.make(color: UIColor.cyan, size: CGSize(width: 640, height: 640))
+
+        return PhotoCapture(
+            forStubbingWith: image,
+            expectedCaptureDuration: .init(value: 0, unit: .seconds),
+            actualCaptureDuration: .init(value: 0, unit: .seconds)
+        )
+    }
+
     init?(
         capture: AVCapturePhoto,
         expectedCaptureDuration: Measurement<UnitDuration>,

--- a/TiltUp.podspec
+++ b/TiltUp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TiltUp'
-  s.version          = '3.0.1'
+  s.version          = '3.1.0'
   s.summary          = 'Official Clutter SDK in Swift to access core iOS features.'
 
   s.description      = <<-DESC

--- a/TiltUpTest.podspec
+++ b/TiltUpTest.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TiltUpTest'
-  s.version          = '3.0.1'
+  s.version          = '3.1.0'
   s.summary          = 'Official Clutter SDK in Swift to access core iOS test helpers.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
## Context
Our automated test suite runs often opens cameras. This runs in the simulator, and isn't properly supported. It causes issues for a few reasons:

1. The camera crashes if interacted with.
2. The camera prompts for a global system dialog permissions.

This fixes by making our simulator capture fake (cyan) square image every time.

## Demo

https://user-images.githubusercontent.com/73432/160961324-a04edb1f-8896-4c9b-bdb3-5aebca685db6.mov


