### PR TITLE
Increase wait

### DIFF
--- a/Example/PodApp/Podfile.lock
+++ b/Example/PodApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - SwiftLint (0.34.0)
-  - TiltUp (3.1.0)
-  - TiltUpTest (3.1.0):
-    - TiltUp (= 3.1.0)
+  - TiltUp (3.1.1)
+  - TiltUpTest (3.1.1):
+    - TiltUp (= 3.1.1)
 
 DEPENDENCIES:
   - SwiftLint
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   SwiftLint: 79d48a17c6565dc286c37efb8322c7b450f95c67
-  TiltUp: 43e69ef22cdba68167a0b4380fc91ed6a741c90a
-  TiltUpTest: be361829df0ae5a2b6a8548f90587bc08fbc119e
+  TiltUp: aa50509a846d0e8435f5332785b0cd9cc46fbe36
+  TiltUpTest: 7e431b060c4ee6ceea8c024c36feb52c7cdb9452
 
 PODFILE CHECKSUM: 0e23ef3e43ff7a2a471fd59d57def6d19f6f9e9e
 

--- a/Sources/TiltUpTest/WaitableCoordinator/WaitableCoordinatorTest.swift
+++ b/Sources/TiltUpTest/WaitableCoordinator/WaitableCoordinatorTest.swift
@@ -22,7 +22,7 @@ public extension WaitableCoordinatorTest where Self: XCTestCase {
             viewControllerChanged?.cancel()
         }
         work()
-        wait(for: [viewControllerChangedExpectation])
+        wait(for: [viewControllerChangedExpectation], timeout: 5.0)
     }
 
     func waitForPresentedViewControllerChange<T: Coordinator>(using coordinator: T, work: () -> Void) {
@@ -33,7 +33,7 @@ public extension WaitableCoordinatorTest where Self: XCTestCase {
             viewControllerChanged?.cancel()
         }
         work()
-        wait(for: [viewControllerChangedExpectation])
+        wait(for: [viewControllerChangedExpectation], timeout: 5.0)
     }
 
     func waitForTopViewControllerChange(in router: Router, work: () -> Void) {
@@ -44,7 +44,7 @@ public extension WaitableCoordinatorTest where Self: XCTestCase {
             viewControllerChanged?.cancel()
         }
         work()
-        wait(for: [viewControllerChangedExpectation])
+        wait(for: [viewControllerChangedExpectation], timeout: 5.0)
     }
 
     func waitForPresentedViewControllerChange(in router: Router, work: () -> Void) {
@@ -55,6 +55,6 @@ public extension WaitableCoordinatorTest where Self: XCTestCase {
             viewControllerChanged?.cancel()
         }
         work()
-        wait(for: [viewControllerChangedExpectation])
+        wait(for: [viewControllerChangedExpectation], timeout: 5.0)
     }
 }

--- a/TiltUp.podspec
+++ b/TiltUp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TiltUp'
-  s.version          = '3.1.0'
+  s.version          = '3.1.1'
   s.summary          = 'Official Clutter SDK in Swift to access core iOS features.'
 
   s.description      = <<-DESC

--- a/TiltUpTest.podspec
+++ b/TiltUpTest.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TiltUpTest'
-  s.version          = '3.1.0'
+  s.version          = '3.1.1'
   s.summary          = 'Official Clutter SDK in Swift to access core iOS test helpers.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Increases wait time for coordinator test helpers since they often fail. This should not have an adverse effect on performance since these tests cannot be inverted.