### PR TITLE
Fix hint label layout for notchless devices

### DIFF
--- a/Sources/TiltUp/Screens/Camera/Views/CameraOverlayView.swift
+++ b/Sources/TiltUp/Screens/Camera/Views/CameraOverlayView.swift
@@ -515,6 +515,9 @@ extension CameraOverlayView {
             atTop = false
         }
 
+        // Apply an offset to the hint view frame based on whether the device has a notch
+        let hintViewYOffset: CGFloat = UIApplication.shared.delegate?.window??.safeAreaInsets.top ?? 0 > 20 ? 112 : 64
+
         let reviewButtonsHidden: Bool
         if case State.confirm = state {
             reviewButtonsHidden = false
@@ -525,28 +528,29 @@ extension CameraOverlayView {
         switch orientation {
         case .portrait:
             transform = .identity
-            hintSuperviewFrame = CGRect(x: 0, y: atTop ? 0 : 112 + frame.width * 4 / 3 - 100, width: frame.width, height: 100)
+            hintSuperviewFrame = CGRect(x: 0, y: atTop ? 0 : hintViewYOffset + frame.width * 4 / 3 - 100, width: frame.width, height: 100)
 
             reviewButtonStack.isHidden = reviewButtonsHidden
             landscapeSaveAndEndCaptureButton.isHidden = true
             landscapeRetakeButton.isHidden = true
             landscapeSaveAndCaptureMoreButton.isHidden = true
+
         case .portraitUpsideDown:
             transform = CGAffineTransform.identity.rotated(by: 180 * .pi / 180)
-            hintSuperviewFrame = CGRect(x: 0, y: atTop ? 0 : 112, width: frame.width, height: 100)
+            hintSuperviewFrame = CGRect(x: 0, y: atTop ? 0 : hintViewYOffset, width: frame.width, height: 100)
             reviewButtonStack.isHidden = reviewButtonsHidden
             landscapeSaveAndEndCaptureButton.isHidden = true
             landscapeRetakeButton.isHidden = true
             landscapeSaveAndCaptureMoreButton.isHidden = true
         case .landscapeRight:
             transform = CGAffineTransform.identity.rotated(by: 90 * .pi / 180)
-            hintSuperviewFrame = CGRect(x: frame.width - 75, y: 112, width: 75, height: frame.width * 4 / 3)
+            hintSuperviewFrame = CGRect(x: frame.width - 75, y: hintViewYOffset, width: 75, height: frame.width * 4 / 3)
             reviewButtonStack.isHidden = true
             landscapeRetakeButton.isHidden = reviewButtonsHidden
             landscapeSaveAndCaptureMoreButton.isHidden = reviewButtonsHidden
         case .landscapeLeft:
             transform = CGAffineTransform.identity.rotated(by: -90 * .pi / 180)
-            hintSuperviewFrame = CGRect(x: 0, y: 112, width: 75, height: frame.width * 4 / 3)
+            hintSuperviewFrame = CGRect(x: 0, y: hintViewYOffset, width: 75, height: frame.width * 4 / 3)
             reviewButtonStack.isHidden = true
             landscapeRetakeButton.isHidden = reviewButtonsHidden
             landscapeSaveAndCaptureMoreButton.isHidden = reviewButtonsHidden

--- a/TiltUp.podspec
+++ b/TiltUp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TiltUp'
-  s.version          = '3.1.1'
+  s.version          = '3.1.2'
   s.summary          = 'Official Clutter SDK in Swift to access core iOS features.'
 
   s.description      = <<-DESC

--- a/TiltUpTest.podspec
+++ b/TiltUpTest.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TiltUpTest'
-  s.version          = '3.1.1'
+  s.version          = '3.1.2'
   s.summary          = 'Official Clutter SDK in Swift to access core iOS test helpers.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Changes in #55 introduced a bug where the hint label on the camera overlay view would overlap with the photo button.
This fix corrects the frame layout regardless of notch status.

Over time we should consider changing how we layout this screen to move away from magic number calculations and use instead use constraints.


## Screenshots

iPhone 8 simulator (notchless), running Field:
![Screen Shot 2022-04-14 at 5 43 14 PM](https://user-images.githubusercontent.com/1318830/163485146-f16d1fa9-6518-46c7-b1e3-a128481b82e4.png)

iPhone 8 Plus (notchless), running Field:
![Screen Shot 2022-04-14 at 6 05 28 PM](https://user-images.githubusercontent.com/1318830/163486039-8aaec2fa-eb5e-4968-bbb6-1e68c38b752d.png)


iPhone 11 (with notch), running Field:
![IMG_2170](https://user-images.githubusercontent.com/1318830/163485635-734d4840-00cc-4bd3-b339-8470fd69ec7a.PNG)

