### PR TITLE
Use AvCapture in PhotoCapture object

### DIFF
--- a/Example/PodApp/Podfile.lock
+++ b/Example/PodApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - SwiftLint (0.34.0)
-  - TiltUp (4.1.0)
-  - TiltUpTest (4.1.0):
-    - TiltUp (= 4.1.0)
+  - TiltUp (5.0.0)
+  - TiltUpTest (5.0.0):
+    - TiltUp (= 5.0.0)
 
 DEPENDENCIES:
   - SwiftLint
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   SwiftLint: 79d48a17c6565dc286c37efb8322c7b450f95c67
-  TiltUp: a690fed7a691faa9e59de9022d382196fe316859
-  TiltUpTest: d4b66493a061126cf4e7e6cc2b4af33a149aed26
+  TiltUp: 3bcf1e978955fbfb898ebff3b2498f8470da40ec
+  TiltUpTest: 329e22e9fc02ebc19ef244a5d51b685828dce911
 
 PODFILE CHECKSUM: 09f75ed10279ae615ecf86a29c2627931ad6bade
 

--- a/Example/Tests/Screens/Camera/PhotoCaptureTests.swift
+++ b/Example/Tests/Screens/Camera/PhotoCaptureTests.swift
@@ -32,7 +32,7 @@ class PhotoCaptureTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            capture.fileDataRepresentation,
+            capture.makeUIImage(scale: 1.0)?.heicData(compressionQuality: 1.0),
             image.heicData(compressionQuality: 1.0)
         )
         XCTAssertEqual(

--- a/Sources/TiltUp/Screens/Camera/CameraViewModel.swift
+++ b/Sources/TiltUp/Screens/Camera/CameraViewModel.swift
@@ -302,10 +302,13 @@ private extension CameraViewModel {
 
         photoSettings.isHighResolutionPhotoEnabled = true
 
-        let photoCaptureDelegate = PhotoCaptureDelegate(uniqueID: photoSettings.uniqueID,
-                                                        willCapturePhotoAnimation: viewObservers.willCapturePhotoAnimation,
-                                                        completionHandler: capturePhotoCompletion,
-                                                        logger: logger)
+        let photoCaptureDelegate = PhotoCaptureDelegate(
+            uniqueID: photoSettings.uniqueID,
+            orientation: currentVideoOrientation,
+            willCapturePhotoAnimation: viewObservers.willCapturePhotoAnimation,
+            completionHandler: capturePhotoCompletion,
+            logger: logger
+        )
 
         inProgressPhotoCaptureDelegates[photoSettings.uniqueID] = photoCaptureDelegate
         photoOutput.capturePhoto(with: photoSettings, delegate: photoCaptureDelegate)

--- a/Sources/TiltUp/Screens/Camera/CameraViewModel.swift
+++ b/Sources/TiltUp/Screens/Camera/CameraViewModel.swift
@@ -287,14 +287,27 @@ private extension CameraViewModel {
             photoOutputConnection.videoOrientation = currentVideoOrientation
         }
 
-        let photoSettings: AVCapturePhotoSettings
-        if  photoOutput.availablePhotoCodecTypes.contains(.hevc) {
-            photoSettings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.hevc])
-        } else {
-            photoSettings = AVCapturePhotoSettings()
+        var photoSettings = AVCapturePhotoSettings()
+        if  self.photoOutput.availablePhotoCodecTypes.contains(.hevc) {
+            photoSettings = AVCapturePhotoSettings(
+                format: [AVVideoCodecKey: AVVideoCodecType.hevc]
+            )
         }
 
         photoSettings.photoQualityPrioritization = .quality
+
+        let previewWidth = 512
+        let previewHeight = 512
+        // Specify a preview image.
+        if !photoSettings.__availablePreviewPhotoPixelFormatTypes.isEmpty,
+           let pixelFormat = photoSettings.__availablePreviewPhotoPixelFormatTypes.first
+        {
+            photoSettings.previewPhotoFormat = [
+                kCVPixelBufferPixelFormatTypeKey: pixelFormat,
+                kCVPixelBufferWidthKey: previewWidth,
+                kCVPixelBufferHeightKey: previewHeight
+            ] as [String: Any]
+        }
 
         if videoDeviceInput.device.isFlashAvailable {
             photoSettings.flashMode = flashMode

--- a/Sources/TiltUp/Screens/Camera/PhotoCapture.swift
+++ b/Sources/TiltUp/Screens/Camera/PhotoCapture.swift
@@ -39,6 +39,10 @@ public struct PhotoCapture {
     public func makeUIImage(scale: CGFloat) -> UIImage? {
         photoCaptureConverter.makeUIImage(orientation: orientation, scale: scale)
     }
+
+    public func makePreviewUIImage() -> UIImage? {
+        photoCaptureConverter.makePreviewUIImage(orientation: orientation)
+    }
 }
 
 // MARK: - Stubbing Support
@@ -59,6 +63,7 @@ public extension PhotoCapture {
 
 protocol PhotoCaptureImageConverter {
     func makeUIImage(orientation: AVCaptureVideoOrientation, scale: CGFloat) -> UIImage?
+    func makePreviewUIImage(orientation: AVCaptureVideoOrientation) -> UIImage?
 }
 
 struct MockPhotoCaptureImageConverter: PhotoCaptureImageConverter {
@@ -67,11 +72,39 @@ struct MockPhotoCaptureImageConverter: PhotoCaptureImageConverter {
     func makeUIImage(orientation: AVCaptureVideoOrientation, scale: CGFloat) -> UIImage? {
         uiImage
     }
+
+    func makePreviewUIImage(orientation: AVCaptureVideoOrientation) -> UIImage? {
+        uiImage
+    }
 }
 
 extension AVCapturePhoto: PhotoCaptureImageConverter  {
     func makeUIImage(orientation: AVCaptureVideoOrientation, scale: CGFloat) -> UIImage? {
         guard let cgImage = self.cgImageRepresentation() else { return nil }
+
+        let imageOrientation: UIImage.Orientation
+        switch orientation {
+        case .portrait:
+            imageOrientation = .right
+        case .portraitUpsideDown:
+            imageOrientation = .left
+        case .landscapeRight:
+            imageOrientation = .up
+        case .landscapeLeft:
+            imageOrientation = .down
+        @unknown default:
+            imageOrientation = .right
+        }
+
+        return UIImage(
+            cgImage: cgImage,
+            scale: scale,
+            orientation: imageOrientation
+        )
+    }
+
+    func makePreviewUIImage(orientation: AVCaptureVideoOrientation) -> UIImage? {
+        guard let cgImage = self.previewCGImageRepresentation() else { return nil }
 
         let imageOrientation: UIImage.Orientation
         switch orientation {

--- a/Sources/TiltUp/Screens/Camera/PhotoCapture.swift
+++ b/Sources/TiltUp/Screens/Camera/PhotoCapture.swift
@@ -9,7 +9,8 @@ import UIKit
 import AVFoundation
 
 public struct PhotoCapture {
-    public let fileDataRepresentation: Data
+    let photoCaptureConverter: PhotoCaptureImageConverter
+    let orientation: AVCaptureVideoOrientation
     public let expectedCaptureDuration: Measurement<UnitDuration>
     public let actualCaptureDuration: Measurement<UnitDuration>
 
@@ -25,15 +26,18 @@ public struct PhotoCapture {
 
     init?(
         capture: AVCapturePhoto,
+        orientation: AVCaptureVideoOrientation,
         expectedCaptureDuration: Measurement<UnitDuration>,
         actualCaptureDuration: Measurement<UnitDuration>
     ) {
-        guard let fileDataRepresentation = capture.fileDataRepresentation() else {
-            return nil
-        }
-        self.fileDataRepresentation = fileDataRepresentation
+        self.photoCaptureConverter = capture
+        self.orientation = orientation
         self.expectedCaptureDuration = expectedCaptureDuration
         self.actualCaptureDuration = actualCaptureDuration
+    }
+
+    public func makeUIImage(scale: CGFloat) -> UIImage? {
+        photoCaptureConverter.makeUIImage(orientation: orientation, scale: scale)
     }
 }
 
@@ -45,11 +49,48 @@ public extension PhotoCapture {
         expectedCaptureDuration: Measurement<UnitDuration>,
         actualCaptureDuration: Measurement<UnitDuration>
     ) {
-        guard let data = image.heicData(compressionQuality: 1.0) else {
-            return nil
-        }
-        self.fileDataRepresentation = data
+        self.photoCaptureConverter = MockPhotoCaptureImageConverter(uiImage: image)
+        self.orientation = .portrait
         self.expectedCaptureDuration = expectedCaptureDuration
         self.actualCaptureDuration = actualCaptureDuration
+    }
+}
+
+
+protocol PhotoCaptureImageConverter {
+    func makeUIImage(orientation: AVCaptureVideoOrientation, scale: CGFloat) -> UIImage?
+}
+
+struct MockPhotoCaptureImageConverter: PhotoCaptureImageConverter {
+    let uiImage: UIImage?
+
+    func makeUIImage(orientation: AVCaptureVideoOrientation, scale: CGFloat) -> UIImage? {
+        uiImage
+    }
+}
+
+extension AVCapturePhoto: PhotoCaptureImageConverter  {
+    func makeUIImage(orientation: AVCaptureVideoOrientation, scale: CGFloat) -> UIImage? {
+        guard let cgImage = self.cgImageRepresentation() else { return nil }
+
+        let imageOrientation: UIImage.Orientation
+        switch orientation {
+        case .portrait:
+            imageOrientation = .right
+        case .portraitUpsideDown:
+            imageOrientation = .left
+        case .landscapeRight:
+            imageOrientation = .up
+        case .landscapeLeft:
+            imageOrientation = .down
+        @unknown default:
+            imageOrientation = .right
+        }
+
+        return UIImage(
+            cgImage: cgImage,
+            scale: 1,
+            orientation: imageOrientation
+        )
     }
 }

--- a/Sources/TiltUp/Screens/Camera/PhotoCaptureDelegate.swift
+++ b/Sources/TiltUp/Screens/Camera/PhotoCaptureDelegate.swift
@@ -15,6 +15,7 @@ final class PhotoCaptureDelegate: NSObject {
     // MARK: Attributes
 
     let uniqueID: Int64
+    private let orientation: AVCaptureVideoOrientation
     private let willCapturePhotoAnimation: (() -> Void)?
     private let completionHandler: (PhotoCaptureDelegate) -> Void
 
@@ -22,12 +23,16 @@ final class PhotoCaptureDelegate: NSObject {
     private(set) var expectedDuration: CMTime?
     private var photoStartedAt: Date?
 
-    init(uniqueID: Int64,
-         willCapturePhotoAnimation: (() -> Void)?,
-         completionHandler: @escaping (PhotoCaptureDelegate) -> Void,
-         logger: Camera.Logger) {
+    init(
+        uniqueID: Int64,
+        orientation: AVCaptureVideoOrientation,
+        willCapturePhotoAnimation: (() -> Void)?,
+        completionHandler: @escaping (PhotoCaptureDelegate) -> Void,
+        logger: Camera.Logger
+    ) {
 
         self.uniqueID = uniqueID
+        self.orientation = orientation
         self.willCapturePhotoAnimation = willCapturePhotoAnimation
         self.completionHandler = completionHandler
         self.logger = logger
@@ -55,6 +60,7 @@ extension PhotoCaptureDelegate: AVCapturePhotoCaptureDelegate {
 
             photoCapture = PhotoCapture(
                 capture: photo,
+                orientation: orientation,
                 expectedCaptureDuration: .init(value: expectedCaptureDuration, unit: .seconds),
                 actualCaptureDuration: .init(value: actualCaptureDuration, unit: .seconds)
             )

--- a/Sources/TiltUp/Screens/Camera/Views/CameraOverlayView.swift
+++ b/Sources/TiltUp/Screens/Camera/Views/CameraOverlayView.swift
@@ -88,8 +88,12 @@ final class CameraOverlayView: UIView {
                 controlPanelFinishButton.isHidden = true
                 flashButton.isHidden = true
 
-                let image = photoCapture.makeUIImage(scale: 0.7)
-                if let cgImage = image?.cgImage, let scale = image?.scale {
+                let image = photoCapture.makePreviewUIImage()
+                if
+                    image?.imageOrientation != .right,
+                    let cgImage = image?.cgImage,
+                    let scale = image?.scale
+                {
                     // Force the preview to display the photo as if it was taken as a portrait
                     // to prevent cropping in our imageview
                     // Camera is mounted at a 90 degree angle so portrait photos have the `.right` image orientation

--- a/Sources/TiltUp/Screens/Camera/Views/CameraOverlayView.swift
+++ b/Sources/TiltUp/Screens/Camera/Views/CameraOverlayView.swift
@@ -88,12 +88,16 @@ final class CameraOverlayView: UIView {
                 controlPanelFinishButton.isHidden = true
                 flashButton.isHidden = true
 
-                let image = UIImage(data: photoCapture.fileDataRepresentation)
+                let image = photoCapture.makeUIImage(scale: 0.7)
                 if let cgImage = image?.cgImage, let scale = image?.scale {
                     // Force the preview to display the photo as if it was taken as a portrait
                     // to prevent cropping in our imageview
                     // Camera is mounted at a 90 degree angle so portrait photos have the `.right` image orientation
-                    previewImageView.image = UIImage(cgImage: cgImage, scale: scale, orientation: .right)
+                    previewImageView.image = UIImage(
+                        cgImage: cgImage,
+                        scale: scale,
+                        orientation: .right
+                    )
                 } else {
                     previewImageView.image = image
                 }

--- a/TiltUp.podspec
+++ b/TiltUp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TiltUp'
-  s.version          = '4.1.0'
+  s.version          = '5.0.0'
   s.summary          = 'Official Clutter SDK in Swift to access core iOS features.'
 
   s.description      = <<-DESC

--- a/TiltUpTest.podspec
+++ b/TiltUpTest.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TiltUpTest'
-  s.version          = '4.1.0'
+  s.version          = '5.0.0'
   s.summary          = 'Official Clutter SDK in Swift to access core iOS test helpers.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Accelerate photo capture and remove unnecessary memory allocations by having the PhotoCapture object yield a UIImage